### PR TITLE
Fix prompt corruption

### DIFF
--- a/src/fsm/state/constants.py
+++ b/src/fsm/state/constants.py
@@ -16,18 +16,18 @@ Visier SQL-like Read Eval Print Loop (REPL) constants.
 """
 
 # SQL-like shell constants
-SQL_PROMPT = "\x1b[1;34;40manalytic> \x1b[1;37;40m"
-SQL_CONTINUE_PROMPT = "\x1b[1;34;40m        | \x1b[1;37;40m"
+SQL_PROMPT = "analytic> "
+SQL_CONTINUE_PROMPT = "        | "
 SQL_OPTIONS = {
         "memberDisplayMode": "COMPACT",
         "zeroVisibility": "ELIMINATE",
         "nullVisibility": "ELIMINATE"
     }
-SQL_STAGING_PROMPT = "\x1b[1;34;40mstaging> \x1b[1;37;40m"
-SQL_STAGING_CONTINUE_PROMPT = "\x1b[1;34;40m       | \x1b[1;37;40m"
+SQL_STAGING_PROMPT = "staging> "
+SQL_STAGING_CONTINUE_PROMPT = "       | "
 
-SQL_TRANSACTION_PROMPT = "\x1b[1;34;40mstaging:tx> \x1b[1;37;40m"
-SQL_TRANSACTION_CONTINUE_PROMPT = "\x1b[1;34;40m          | \x1b[1;37;40m"
+SQL_TRANSACTION_PROMPT = "staging:tx> "
+SQL_TRANSACTION_CONTINUE_PROMPT = "          | "
 
 STATE_ANALYTIC = "analytic_state"
 STATE_STAGING = "staging_state"

--- a/src/repl/__init__.py
+++ b/src/repl/__init__.py
@@ -18,4 +18,4 @@ Visier SQL-like Read Eval Print Loop (REPL) module
 from .shell import SqlLikeShell
 from .cmd_queue import CommandQueue
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"

--- a/src/repl/constants.py
+++ b/src/repl/constants.py
@@ -28,4 +28,4 @@ SET schema TO staging;
 Each SQL-like statement must be terminated with a semicolon (;) in order to execute.
 \x1b[;;40m
 """
-SQL_BYE = "\x1b[1;32;40mClosing the application\x1b[0m"
+SQL_EXIT = "\x1b[1;32;40mClosing the application\x1b[0m"

--- a/src/repl/shell.py
+++ b/src/repl/shell.py
@@ -20,7 +20,7 @@ from visier.connector import VisierSession
 from fsm import mk_fsm
 from fsm.state.constants import SCHEMA_MAP
 from .cmd_queue import CommandQueue
-from .constants import SQL_INTRO, SQL_BYE
+from .constants import SQL_INTRO, SQL_EXIT
 
 
 class SqlLikeShell(Cmd):
@@ -49,14 +49,27 @@ class SqlLikeShell(Cmd):
         else:
             self.prompt = self._fsm.prompt()
 
-    def emptyline(self):
-        """
-        Empty line handler
-        """
-
     def do_bye(self, _):
         """
         Exit the SQL-like shell
         """
-        print(SQL_BYE)
+        return self._exit()
+
+    def do_exit(self, _):
+        """
+        Exit the SQL-like shell
+        """
+        return self._exit()
+
+    def do_quit(self, _):
+        """
+        Exit the SQL-like shell
+        """
+        return self._exit()
+
+    def _exit(self):
+        """
+        Exit the SQL-like shell
+        """
+        print(SQL_EXIT)
         return True


### PR DESCRIPTION
Cmd module doesn't handle up-arrow history traversal when the prompt includes Python colour markers so this change removes them.