### PR TITLE
add emptyline handler back in

### DIFF
--- a/src/repl/__init__.py
+++ b/src/repl/__init__.py
@@ -18,4 +18,4 @@ Visier SQL-like Read Eval Print Loop (REPL) module
 from .shell import SqlLikeShell
 from .cmd_queue import CommandQueue
 
-__version__ = "0.9.3"
+__version__ = "0.9.4"

--- a/src/repl/shell.py
+++ b/src/repl/shell.py
@@ -49,6 +49,9 @@ class SqlLikeShell(Cmd):
         else:
             self.prompt = self._fsm.prompt()
 
+    def emptyline(self) -> bool:
+        """Empty line handler. Do nothing."""
+
     def do_bye(self, _):
         """
         Exit the SQL-like shell


### PR DESCRIPTION
Regression caused by the prompt fix where the empty lines handler was removed when exploring Cmd2