### PR TITLE
change transaction prompt

### DIFF
--- a/src/fsm/state/constants.py
+++ b/src/fsm/state/constants.py
@@ -26,8 +26,7 @@ SQL_OPTIONS = {
 SQL_STAGING_PROMPT = "staging> "
 SQL_STAGING_CONTINUE_PROMPT = "       | "
 
-SQL_TRANSACTION_PROMPT = "staging:tx> "
-SQL_TRANSACTION_CONTINUE_PROMPT = "          | "
+SQL_TRANSACTION_CONTINUE_PROMPT = "       | "
 
 STATE_ANALYTIC = "analytic_state"
 STATE_STAGING = "staging_state"

--- a/src/repl/__init__.py
+++ b/src/repl/__init__.py
@@ -18,4 +18,4 @@ Visier SQL-like Read Eval Print Loop (REPL) module
 from .shell import SqlLikeShell
 from .cmd_queue import CommandQueue
 
-__version__ = "0.9.6"
+__version__ = "0.9.7"


### PR DESCRIPTION
Include the transaction id in the transaction prompt in order to enable transaction status checks using the `/v1/data/directloads/prod/transactions/$tx_id` API